### PR TITLE
Added support for more options available in the getMonitors API Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Created by https://www.gitignore.io
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/uptimerobot/uptimerobot.py
+++ b/uptimerobot/uptimerobot.py
@@ -41,13 +41,28 @@ class UptimeRobot(object):
             return False
         
         
-    def getMonitors(self):
-        """ 
+    def getMonitors(self, response_times=0, logs=0, uptime_ratio=''):
+        """
         Returns status and response payload for all known monitors.
         """
         url = self.baseUrl
         url += "getMonitors?apiKey=%s" % (self.apiKey)
         url += "&noJsonCallback=1&format=json"
+        # responseTimes - optional (defines if the response time data of each
+        # monitor will be returned. Should be set to 1 for getting them. Default
+        # is 0)
+        if response_times:
+            url += "&responseTimes=1"
+        # logs - optional (defines if the logs of each monitor will be returned.
+        # Should be set to 1 for getting the logs. Default is 0)
+        if logs:
+            url += '&logs=1'
+        # customUptimeRatio - optional (defines the number of days to calculate
+        # the uptime ratio(s) for. Ex: customUptimeRatio=7-30-45 to get the
+        # uptime ratios for those periods)
+        if uptime_ratio:
+            url += '&customUptimeRatio=%s' % uptime_ratio
+
         return self.requestApi(url)
         
         


### PR DESCRIPTION
Added support for more options available in the getMonitors API Methods. It now allows to return the logs, the response times and the custom uptime ratio. It won't break the old implementation as all the new options are optional like in the API documentation.

e.g.: 

    >>> from uptimerobot.uptimerobot import UptimeRobot
    >>> up = UptimeRobot(UPTIME_ROBOT_API_KEY)
    >>> up.getMonitors(logs=1, response_times=1, uptime_ratio='1-7-30')
